### PR TITLE
Check for and exclude thumbnails

### DIFF
--- a/class.add-from-server.php
+++ b/class.add-from-server.php
@@ -522,6 +522,13 @@ class Plugin {
 						} else if ( 'unreadable' === $file['error'] ) {
 							$error_str = __( 'Sorry, but this file is unreadable by your Webserver. Perhaps check your File Permissions?', 'add-from-server' );
 						}
+						
+						// Check for and exclude thumbnails images
+						preg_match_all('/.*\dx\d+\.(png|jpg|jpeg)/m', $file['text'], $matches, PREG_SET_ORDER, 0);
+						if (count($matches)) continue;
+						
+						// Check for and exclude updraft images
+						if (stripos($file['text'],'updraft-pre-smush-original') !== false) continue;
 
 						printf(
 							'<tr class="%1$s" title="%2$s">


### PR DESCRIPTION
There is no checking for thumbnails already imported to the wordpress library, so if a thumbnail is detected, it should be ignored from the list. I also added checking for original images from updraft to exclude those from the list as well.

Ideally, there would be a settings toggle to hide or show thumbnails. Personally, as for the official build of this plugin, I would recommend only implementing the thumbnail option as updraft is a very user-specific option.

As for this PR, I am including both filters so you can use either of them if you would like. I am more than happy to continue the conversation to get this into the official plugin based on your recommendations. 

Thanks for this plugin! With my changes, it saved me a ton of time!!!